### PR TITLE
[콘서트티켓북][#13] 상세 페이지 컴포넌트 구현

### DIFF
--- a/apps/oh-sang-hyeop/src/app/globals.css
+++ b/apps/oh-sang-hyeop/src/app/globals.css
@@ -24,3 +24,12 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+/* styles/globals.css */
+.scrollbar-hide::-webkit-scrollbar {
+  display: none;
+}
+.scrollbar-hide {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}

--- a/apps/oh-sang-hyeop/src/components/ItemDetail/ItemDetail.tsx
+++ b/apps/oh-sang-hyeop/src/components/ItemDetail/ItemDetail.tsx
@@ -1,0 +1,57 @@
+import { ItemDetailData } from '@/types/item';
+import ItemImageSection from './sections/ItemImageSection';
+import ItemInfoSection from './sections/ItemInfoSection';
+import ItemExtraImageSection from './sections/ItemExtraImageSection';
+
+export default function ItemDetail(props: ItemDetailData) {
+  return (
+    <div className="flex gap-10 p-10 border rounded-2xl shadow-md w-full">
+      <ItemImageSection {...props} />
+      <div className="flex-1 flex flex-col justify-between">
+        <ItemInfoSection {...props} />
+        <ItemExtraImageSection extraImages={props.extraImages || []} />
+      </div>
+    </div>
+  );
+}
+
+/*
+예시코드
+
+'use client';
+
+import ItemDetail from '@/components/ItemDetail/ItemDetail';
+import { ItemDetailData } from '@/types/item';
+
+export default function ItemDetailTestPage() {
+  const dummyData: ItemDetailData = {
+    type: 'concert', // 'album' 또는 'goods'로도 변경해보세요
+    title: 'The Golden Hour : 오렌지 태양 아래',
+    image: '/concert.webp', // public 디렉토리에 미리 넣어주세요
+    extraImages: [
+      '/sub1.webp',
+      '/sub2.webp',
+      '/sub3.webp',
+      '/sub4.webp',
+      '/sub5.webp',
+      '/sub6.webp',
+    ],
+    artist: '아이유',
+    date: '2022-09-18',
+    location: '서울올림픽주경기장',
+    cost: 165000,
+    popularity: 5,
+    review: '대 이 유',
+  };
+
+  return (
+    <div className="w-screen h-screen flex items-center justify-center bg-neutral-100">
+      <div className="w-[90%] max-w-[1600px]">
+        <ItemDetail {...dummyData} />
+      </div>
+    </div>
+  );
+}
+
+
+*/

--- a/apps/oh-sang-hyeop/src/components/ItemDetail/sections/ItemExtraImageSection.tsx
+++ b/apps/oh-sang-hyeop/src/components/ItemDetail/sections/ItemExtraImageSection.tsx
@@ -1,0 +1,71 @@
+/*
+@file ItemExtraImageSection.tsx
+@description 상세 페이지에서 추가 이미지들을 수평 스크롤로 표시
+*/
+
+'use client';
+
+import Image from 'next/image';
+import { useEffect, useRef } from 'react';
+
+interface Props {
+  extraImages: string[];
+}
+
+export default function ItemExtraImageSection({ extraImages }: Props) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const imageWidth = 250 + 12;
+  const visibleCount = 4;
+  const totalWidth = extraImages.length * imageWidth;
+
+  // 휠 → 수평 스크롤
+  const handleWheelScroll = (e: React.WheelEvent<HTMLDivElement>) => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollLeft += e.deltaY;
+    }
+  };
+
+  // 무한 스크롤 처리
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+
+    const handleScroll = () => {
+      if (el.scrollLeft >= totalWidth) {
+        el.scrollLeft -= totalWidth;
+      }
+    };
+
+    el.addEventListener('scroll', handleScroll);
+    return () => el.removeEventListener('scroll', handleScroll);
+  }, [totalWidth]);
+
+  if (!extraImages || extraImages.length === 0) return null;
+
+  return (
+    <div className="pt-6 pb-4 space-y-4 min-h-[250px]">
+      <p className="text-lg font-semibold">📷 추가 이미지</p>
+
+      <div
+        ref={scrollRef}
+        onWheel={handleWheelScroll}
+        className="flex gap-3 overflow-x-auto scrollbar-hide"
+        style={{
+          maxWidth: `${imageWidth * visibleCount}px`,
+          WebkitOverflowScrolling: 'touch',
+        }}
+      >
+        {[...extraImages, ...extraImages].map((img, i) => (
+          <Image
+            key={i}
+            src={img}
+            alt={`추가 이미지 ${i + 1}`}
+            width={250}
+            height={250}
+            className="rounded-md object-cover border shrink-0"
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/oh-sang-hyeop/src/components/ItemDetail/sections/ItemImageSection.tsx
+++ b/apps/oh-sang-hyeop/src/components/ItemDetail/sections/ItemImageSection.tsx
@@ -1,0 +1,34 @@
+/*
+@file ItemImageSection.tsx
+@description 상세 페이지에서 메인이미지와 아티스트, 날짜, 장소 등의 정보를 표시
+*/
+
+import Image from 'next/image';
+import { ItemDetailData } from '@/types/item';
+
+export default function ItemImageSection({
+  image,
+  artist,
+  date,
+  location,
+  type,
+}: ItemDetailData) {
+  return (
+    <div className="w-1/3 space-y-4">
+      <Image
+        src={image}
+        alt={`${artist} 이미지`}
+        width={420}
+        height={420}
+        className="rounded-md object-cover"
+      />
+      <div className="text-xl space-y-2">
+        <p><strong>아티스트:</strong> {artist}</p>
+        <p><strong>{type === 'concert' ? '날짜' : '출시일'}:</strong> {date}</p>
+        {type === 'concert' && location && (
+          <p><strong>장소:</strong> {location}</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/oh-sang-hyeop/src/components/ItemDetail/sections/ItemInfoSection.tsx
+++ b/apps/oh-sang-hyeop/src/components/ItemDetail/sections/ItemInfoSection.tsx
@@ -1,0 +1,85 @@
+/*
+@file ItemInfoSection.tsx
+@description 상세 페이지에서 제목, 비용, 별점, 감상평 등을 표시
+*/
+
+'use client';
+
+import { Button, Rating, TextField } from '@mui/material';
+import { ItemDetailData } from '@/types/item';
+
+interface Props extends ItemDetailData {
+  onEdit?: () => void;
+}
+
+export default function ItemInfoSection({
+  title,
+  type,
+  cost,
+  popularity,
+  review,
+  onEdit,
+}: Props) {
+  const getCostLabel = () => {
+    if (type === 'concert') return '티켓 비용';
+    if (type === 'album') return '앨범 비용';
+    return '굿즈 비용';
+  };
+
+
+  return (
+    <div className="flex-1 relative space-y-4 p-2">
+      {/* ✏️ MUI 수정 버튼 (오른쪽 상단) */}
+      <Button
+        variant="outlined"
+        size="large"
+        onClick={onEdit}
+        sx={{
+          position: 'absolute',
+          top: 0,
+          right: 0,
+          m: 1,
+          textTransform: 'none',
+        }}
+      >
+        수정
+      </Button>
+  {/* 제목 */}
+      <h1 className="text-4xl font-bold">{title}</h1>
+
+      {/* 내용 */}
+      <div className="space-y-2 text-2xi">
+        <p>
+          <strong>{getCostLabel()}:</strong> {cost.toLocaleString()}원
+        </p>
+
+        <div className="flex items-center gap-2">
+          <strong>별점:</strong>
+          <Rating
+            name="popularity"
+            value={popularity}
+            precision={0.5}
+            readOnly
+            size="medium"
+          />
+        </div>
+
+        {/* 감상평 */}
+        <div>
+          <TextField
+  fullWidth
+  multiline
+  minRows={3}
+  value={review || ''}
+  placeholder="감상평이 없습니다."
+  slotProps={{
+    input: {
+      readOnly: true,
+    },
+  }}
+/>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/oh-sang-hyeop/src/types/item.ts
+++ b/apps/oh-sang-hyeop/src/types/item.ts
@@ -1,0 +1,15 @@
+// types/item.ts
+export type ItemType = 'concert' | 'album' | 'goods';
+
+export interface ItemDetailData {
+  type: ItemType;
+  title: string;
+  image: string;
+  extraImages?: string[];
+  artist: string;
+  date: string;
+  location?: string; // 콘서트만 표시
+  cost: number;
+  review?: string;    // 감상평 내용
+  popularity: number;
+}


### PR DESCRIPTION
### 관련이슈
- #13 

### 구현내용
ItemImageSection
  - 메인 이미지 표시 
  - 아티스트명, 공연일자/출시일, 장소 정보 함께 표시

ItemInfoSection 컴포넌트 구현
  - 제목, 비용 정보 출력
  - 별점(MUI Rating)으로 만족도 표현
  - 감상평(TextField) 
  - 우측 상단에 MUI Button 기반 "수정" 버튼 

ItemExtraImageSection 컴포넌트 구현
  - 가로 썸네일 리스트
  - 마우스 휠로 스크롤 가능
  - 좌우로 무한 스크롤 느낌 구현
  
![image](https://github.com/user-attachments/assets/46eb50cb-05c1-43ae-80ec-32d8336d2a55)

  
  