### PR TITLE
[콘서트티켓북][#18] BookLayout 공통 레이아웃 컴포넌트 생성

### DIFF
--- a/apps/oh-sang-hyeop/src/components/book/BookLayout.tsx
+++ b/apps/oh-sang-hyeop/src/components/book/BookLayout.tsx
@@ -47,7 +47,7 @@ export default function BookLayout({
       </div>
 
       {/* 펼쳐진 책 구조 */}
-      <div className="relative w-[960px] h-[600px] flex shadow-lg rounded-xl overflow-hidden">
+      <div className="relative w-[1200px] h-[600px] flex shadow-lg rounded-xl overflow-hidden">
         {/* 왼쪽 */}
         <div className="w-1/2 bg-white p-6 overflow-y-auto border-r border-gray-300">
           {leftPage}

--- a/apps/oh-sang-hyeop/src/components/book/BookLayout.tsx
+++ b/apps/oh-sang-hyeop/src/components/book/BookLayout.tsx
@@ -1,0 +1,94 @@
+/*
+@file BookLayout.tsx
+@description 책 레이아웃 컴포넌트로, 왼쪽과 오른쪽 페이지를 나누어 표시하고, 상단에 제목과 버튼을 배치합니다.
+*/
+'use client';
+
+import { Button } from '@mui/material';
+
+type BookType = 'concert' | 'album' | 'goods';
+
+interface BookLayoutProps {
+  title: string;
+  type: BookType;
+  onCreate: () => void;
+  leftPage: React.ReactNode;
+  rightPage: React.ReactNode;
+}
+
+const getCreateButtonLabel = (type: BookType) => {
+  switch (type) {
+    case 'concert':
+      return '티켓 추가';
+    case 'album':
+      return '앨범 추가';
+    case 'goods':
+      return '굿즈 추가';
+    default:
+      return '항목 추가';
+  }
+};
+
+export default function BookLayout({
+  title,
+  type,
+  onCreate,
+  leftPage,
+  rightPage,
+}: BookLayoutProps) {
+  return (
+    <div className="min-h-screen bg-[#f8f6f2] py-10 flex flex-col items-center">
+      {/* 상단 헤더 */}
+      <div className="w-full max-w-6xl flex justify-between items-center mb-6 px-4">
+        <h1 className="text-3xl font-bold">{title}</h1>
+        <Button variant="contained" onClick={onCreate}>
+          {getCreateButtonLabel(type)}
+        </Button>
+      </div>
+
+      {/* 펼쳐진 책 구조 */}
+      <div className="relative w-[960px] h-[600px] flex shadow-lg rounded-xl overflow-hidden">
+        {/* 왼쪽 */}
+        <div className="w-1/2 bg-white p-6 overflow-y-auto border-r border-gray-300">
+          {leftPage}
+        </div>
+
+        {/* 중앙 접힘 */}
+        <div className="w-[6px] bg-gradient-to-b from-gray-300 via-gray-100 to-gray-300 shadow-inner" />
+
+        {/* 오른쪽 */}
+        <div className="w-1/2 bg-white p-6 overflow-y-auto">
+          {rightPage}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+
+/* 테스트 코드
+'use client';
+
+import BookLayout from '@/components/book/BookLayout';
+
+export default function BookLayoutPreviewPage() {
+  return (
+    <BookLayout
+      title="디자인 미리보기"
+      type="concert"
+      onCreate={() => alert('버튼 클릭')}
+      leftPage={
+        <div className="flex flex-col items-center justify-center h-full text-gray-400">
+          👉 왼쪽 페이지
+        </div>
+      }
+      rightPage={
+        <div className="flex flex-col items-center justify-center h-full text-gray-400">
+          👉 오른쪽 페이지
+        </div>
+      }
+    />
+  );
+}
+
+*/


### PR DESCRIPTION
### 관련 이슈
- #18

---

### 구현 내용
- `BookLayout` 공통 레이아웃 컴포넌트 생성
- `title`, `type`, `onCreate`, `leftPage`, `rightPage` props 구성
- `type`에 따라 버튼 라벨을 자동으로 설정 (티켓 추가 / 앨범 추가 / 굿즈 추가)
- Tailwind 기반의 책 펼침 구조 레이아웃 구현
  - 좌우 페이지 분할
  - 가운데 접힘선 표현

---

![image](https://github.com/user-attachments/assets/31ff531a-d6f5-4438-8613-6418b8e6add7)
