### PR TITLE
[콘서트티켓북][#19] 티켓북 페이지, TicketCard, TicketList 컴포넌트 구현

### DIFF
--- a/apps/oh-sang-hyeop/src/app/ticket/page.tsx
+++ b/apps/oh-sang-hyeop/src/app/ticket/page.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import BookLayout from '@/components/book/BookLayout';
+import TicketList from '@/components/ticket/TicketList';
+
+interface Ticket {
+  title: string;
+  artist: string;
+  date: string;
+  location: string;
+  thumbnail: string;
+}
+
+
+export default function TicketPage() {
+  const router = useRouter();
+
+  // 예시 티켓 4개
+ const tickets: Ticket[] = [
+  {
+    title: '아이유 콘서트',
+    artist: '아이유',
+    date: '2024-11-01',
+    location: 'KSPO DOME',
+    thumbnail: '/images/ex1.jpg',
+  },
+  {
+    title: '아이묭 콘서트',
+    artist: '아이묭',
+    date: '2024-10-15',
+    location: '도쿄돔',
+    thumbnail: '/images/ex2.webp',
+  },
+  {
+    title: '에스파 콘서트',
+    artist: '에스파',
+    date: '2024-12-05',
+    location: '고척스카이돔',
+    thumbnail: '/images/ex3.webp',
+  },
+  {
+    title: '요아소비 콘서트',
+    artist: '요아소비',
+    date: '2025-01-20',
+    location: '인스파이어 아레나',
+    thumbnail: '/images/ex4.jpg',
+  },
+];
+
+
+  // 좌측 2개, 우측 2개
+  const leftTickets = tickets.slice(0, 2);
+  const rightTickets = tickets.slice(2, 4);
+
+  return (
+    <BookLayout
+      title="티켓북"
+      type="concert"
+      onCreate={() => router.push('/ticket/new')}
+      leftPage={
+        <TicketList
+          tickets={leftTickets}
+          onSelect={(ticket) => console.log('선택된 티켓:', ticket)}
+        />
+      }
+      rightPage={
+        <TicketList
+          tickets={rightTickets}
+          onSelect={(ticket) => console.log('선택된 티켓:', ticket)}
+        />
+      }
+    />
+  );
+}

--- a/apps/oh-sang-hyeop/src/components/ticket/TicketCard.tsx
+++ b/apps/oh-sang-hyeop/src/components/ticket/TicketCard.tsx
@@ -1,0 +1,51 @@
+import Image from 'next/image';
+
+interface TicketCardProps {
+  title: string;
+  artist: string;
+  date: string;
+  location: string;
+  thumbnail: string;
+  onClick?: () => void;
+}
+
+export default function TicketCard({
+  title,
+  artist,
+  date,
+  location,
+  thumbnail,
+  onClick,
+}: TicketCardProps) {
+  return (
+    <div
+      className="flex items-center bg-purple-100 rounded-xl overflow-hidden cursor-pointer shadow-lg h-63 w-full"
+      onClick={onClick}
+    >
+      {/* 왼쪽 이미지 */}
+      <div className="relative w-40 aspect-[7/10] m-4 flex-shrink-0">
+        <Image
+          src={thumbnail}
+          alt={title}
+          fill
+          className="object-cover rounded-md"
+          sizes="1920px"
+          quality={100}
+        />
+      </div>
+
+      {/* 오른쪽 내용 */}
+      <div className="flex flex-col justify-center flex-1 p-2">
+        <h2 className="text-lg font-bold text-purple-900">{title}</h2>
+        <div className="text-sm text-purple-800 mt-1 ">
+          <br />
+          아티스트: {artist}
+          <br />
+          날짜: {date}
+          <br />
+          장소: {location}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/oh-sang-hyeop/src/components/ticket/TicketList.tsx
+++ b/apps/oh-sang-hyeop/src/components/ticket/TicketList.tsx
@@ -1,0 +1,32 @@
+import TicketCard from './TicketCard';
+
+interface Ticket {
+  title: string;
+  artist: string;
+  date: string;
+  location: string;
+  thumbnail: string;
+}
+
+interface TicketListProps {
+  tickets: Ticket[];
+  onSelect?: (ticket: Ticket) => void;
+}
+
+export default function TicketList({ tickets, onSelect }: TicketListProps) {
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      {tickets.map((ticket, idx) => (
+        <TicketCard
+          key={idx}
+          title={ticket.title}
+          artist={ticket.artist}
+          date={ticket.date}
+          location={ticket.location}
+          thumbnail={ticket.thumbnail}
+          onClick={() => onSelect?.(ticket)}
+        />
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
### 관련이슈
- #19 
---
### 구현내용
- 콘서트 티켓 정보를 보여주는 티켓북 페이지 구현
- `BookLayout` 공통 컴포넌트를 활용해 좌우 페이지 구성
  - 좌측 페이지: TicketList(티켓 2개)
  - 우측 페이지: TicketList(티켓 2개)
- TicketCard 컴포넌트 작성
  - 썸네일 이미지
  - 콘서트명
  - 아티스트명
  - 날짜
  - 장소
- TicketList 컴포넌트 작성
  - 한 페이지에 2개의 티켓 카드 표시
  - 클릭 시 console.log 로 선택 티켓 로그 출력
- 작성 버튼 클릭 시 `/ticket/new` 페이지로 이동

---

![image](https://github.com/user-attachments/assets/bf0df30a-a0f8-491e-8630-aa8d709fa575)
