### PR TITLE
[콘서트티켓북][#20] 앨범북 페이지 및 CD형 AlbumCard 컴포넌트 구현

### DIFF
--- a/apps/oh-sang-hyeop/src/app/album/page.tsx
+++ b/apps/oh-sang-hyeop/src/app/album/page.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import BookLayout from '@/components/book/BookLayout';
+import AlbumCard from '@/components/album/AlbumCard';
+
+interface Album {
+  title: string;
+  artist: string;
+  releaseDate: string;
+  thumbnail: string;
+}
+
+export default function AlbumPage() {
+  const router = useRouter();
+
+  // 목업 데이터
+  const albums: Album[] = [
+    {
+      title: '아이유 꽃갈피 셋',
+      artist: '아이유',
+      releaseDate: '2024-09-01',
+      thumbnail: '/images/iu_album.webp',
+    },
+    {
+      title: 'THE BOOK 1',
+      artist: 'YOASOBI',
+      releaseDate: '2024-11-20',
+      thumbnail: '/images/yoasobi_album.jpg',
+    },
+  ];
+
+  return (
+    <BookLayout
+      title="앨범북"
+      type="album"
+      onCreate={() => router.push('/album/new')}
+      leftPage={
+        <AlbumCard
+          album={albums[0]!}
+        />
+      }
+      rightPage={
+        <AlbumCard
+          album={albums[1]!}
+         />
+      }
+      
+    />
+  );
+}

--- a/apps/oh-sang-hyeop/src/components/album/AlbumCard.tsx
+++ b/apps/oh-sang-hyeop/src/components/album/AlbumCard.tsx
@@ -1,0 +1,45 @@
+import styles from '@/styles/AlbumCard.module.css';
+
+interface Album {
+  title: string;
+  artist: string;
+  releaseDate: string;
+  thumbnail: string;
+}
+
+interface AlbumCardProps {
+  album: Album;
+}
+
+export default function AlbumCard({ album }: AlbumCardProps) {
+  const { title, artist, releaseDate, thumbnail } = album;
+
+  return (
+    <div className="flex justify-center items-center h-full">
+      <div
+        className="flex flex-col items-center justify-center w-[90%] h-[90%] border-2 border-purple-400 rounded-lg bg-purple-50 p-1 shadow-md cursor-pointer"
+        onClick={() => console.log('선택된 앨범:', title)}
+      >
+        {/* 텍스트 */}
+        <h2 className="text-lg font-bold text-purple-900 mb-2">{title}</h2>
+
+        <div className="flex flex-col items-center gap-2 p-4">
+          {/* CD 모양 */}
+          <div className={`${styles.spinOnHover} relative w-80 h-80 rounded-full border-2 border-purple-400 overflow-hidden shadow-lg`}>
+            <img
+              src={thumbnail}
+              alt={title}
+              className="w-full h-full object-cover rounded-full"
+            />
+            {/* CD 중심 구멍 */}
+            <div className="absolute top-1/2 left-1/2 w-8 h-8 bg-white rounded-full border-2 border-purple-400 transform -translate-x-1/2 -translate-y-1/2" />
+          </div>
+          <div className="text-xs text-purple-700 text-center mt-2">
+            {artist}<br />
+            {releaseDate}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/oh-sang-hyeop/src/styles/AlbumCard.module.css
+++ b/apps/oh-sang-hyeop/src/styles/AlbumCard.module.css
@@ -1,0 +1,13 @@
+.spinOnHover:hover img {
+    animation: spin 4s linear infinite;
+    transform-origin: 50% 50%;
+}
+
+@keyframes spin {
+    0% {
+        transform: rotate(0deg);
+    }
+
+    100% {
+        transform: rotate(360deg);
+    } }


### PR DESCRIPTION
### 관련 이슈
- #20
---
### 구현 내용
- 앨범북 메인 페이지 (`/album`) 구성
- CD형 `AlbumCard` 컴포넌트 구현
  - 앨범 이미지, 제목, 발매일 등을 표시
- 레이아웃 구조 초안 작성
---
<img width="1134" alt="스크린샷 2025-06-27 오후 9 59 55" src="https://github.com/user-attachments/assets/5ad1535a-ed02-4836-b833-72b003385df4" />
