### PR TITLE
[콘서트티켓북][#21] 굿즈페이지 및 사이드바 구현

### DIFF
--- a/apps/oh-sang-hyeop/src/app/goods/page.tsx
+++ b/apps/oh-sang-hyeop/src/app/goods/page.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import GoodsList from "@/components/goods/goodsList";
+import BookLayout from "@/components/book/BookLayout"; // 이미 구현돼 있다고 가정
+import { useState } from "react";
+import { GoodsItem } from "@/types/goods";
+
+export default function GoodsPage() {
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  const goods: GoodsItem[] = [
+    { id: 'g1', name: '응원봉', imageUrl: '/goods/lightstick.jpg' },
+    { id: 'g2', name: '포토카드', imageUrl: '/goods/photocard.jpg' },
+    { id: 'g3', name: '키링', imageUrl: '/goods/keyring.webp' },
+    { id: 'g4', name: '티셔츠',imageUrl: '/goods/tshirt.jpg' },
+    { id: 'g5', name: '후드집업', imageUrl: '/goods/hoodie.webp' },
+    { id: 'g6', name: '에코백', imageUrl: '/goods/ecobag.webp' },
+    { id: 'g7', name: '캡모자', imageUrl: '/goods/cap.webp' },
+    { id: 'g8', name: '팔찌', imageUrl: '/goods/bracelet.webp' },
+  ];
+
+  return (
+    <BookLayout
+      title="굿즈 목록"
+      type="goods"
+      onCreate={() => { /* TODO: implement create handler */ }}
+      leftPage={
+        <GoodsList
+          goods={goods.slice(0, 4)}
+          onSelect={(id) => setSelectedId(id)}
+        />
+      }
+      rightPage={
+        <GoodsList
+          goods={goods.slice(4, 8)}
+          onSelect={(id) => setSelectedId(id)}
+        />
+      }
+    />
+  );
+}

--- a/apps/oh-sang-hyeop/src/components/book/BookLayout.tsx
+++ b/apps/oh-sang-hyeop/src/components/book/BookLayout.tsx
@@ -1,10 +1,11 @@
 /*
 @file BookLayout.tsx
-@description 책 레이아웃 컴포넌트로, 왼쪽과 오른쪽 페이지를 나누어 표시하고, 상단에 제목과 버튼을 배치합니다.
+@description 책 레이아웃 컴포넌트로, 왼쪽에 사이드바를 고정하고, 오른쪽에 책 펼침 화면을 표시합니다.
 */
 'use client';
 
 import { Button } from '@mui/material';
+import Sidebar from '@/components/sidebar/sidebar';
 
 type BookType = 'concert' | 'album' | 'goods';
 
@@ -37,34 +38,39 @@ export default function BookLayout({
   rightPage,
 }: BookLayoutProps) {
   return (
-    <div className="min-h-screen bg-[#f8f6f2] py-10 flex flex-col items-center">
-      {/* 상단 헤더 */}
-      <div className="w-full max-w-6xl flex justify-between items-center mb-6 px-4">
-        <h1 className="text-3xl font-bold">{title}</h1>
-        <Button variant="contained" onClick={onCreate}>
-          {getCreateButtonLabel(type)}
-        </Button>
-      </div>
+    <div className="flex min-h-screen bg-[#f8f6f2]">
+      {/* Sidebar */}
+      <Sidebar />
 
-      {/* 펼쳐진 책 구조 */}
-      <div className="relative w-[1200px] h-[600px] flex shadow-lg rounded-xl overflow-hidden">
-        {/* 왼쪽 */}
-        <div className="w-1/2 bg-white p-6 overflow-y-auto border-r border-gray-300">
-          {leftPage}
+      {/* 책 본문 영역 */}
+      <div className="flex-1 flex flex-col justify-center items-center py-10">
+        {/* 상단 헤더 */}
+        <div className="w-full max-w-6xl flex justify-between items-center mb-6 px-4">
+          <h1 className="text-3xl font-bold text-gray-800">{title}</h1>
+          <Button variant="contained" onClick={onCreate}>
+            {getCreateButtonLabel(type)}
+          </Button>
         </div>
 
-        {/* 중앙 접힘 */}
-        <div className="w-[6px] bg-gradient-to-b from-gray-300 via-gray-100 to-gray-300 shadow-inner" />
+        {/* 펼쳐진 책 구조 */}
+        <div className="relative w-[1200px] h-[600px] flex shadow-lg rounded-xl overflow-hidden">
+          {/* 왼쪽 페이지 */}
+          <div className="w-1/2 bg-white p-6 overflow-y-auto border-r border-gray-300">
+            {leftPage}
+          </div>
 
-        {/* 오른쪽 */}
-        <div className="w-1/2 bg-white p-6 overflow-y-auto">
-          {rightPage}
+          {/* 중앙 접힘 */}
+          <div className="w-[6px] bg-gradient-to-b from-gray-300 via-gray-100 to-gray-300 shadow-inner" />
+
+          {/* 오른쪽 페이지 */}
+          <div className="w-1/2 bg-white p-6 overflow-y-auto">
+            {rightPage}
+          </div>
         </div>
       </div>
     </div>
   );
 }
-
 
 /* 테스트 코드
 'use client';
@@ -90,5 +96,4 @@ export default function BookLayoutPreviewPage() {
     />
   );
 }
-
 */

--- a/apps/oh-sang-hyeop/src/components/goods/goodsCard.tsx
+++ b/apps/oh-sang-hyeop/src/components/goods/goodsCard.tsx
@@ -1,0 +1,27 @@
+import Image from "next/image";
+import { GoodsItem } from "@/types/goods";
+
+interface GoodsCardProps {
+  item: GoodsItem;
+  onSelect?: (id: string) => void;
+}
+
+export default function GoodsCard({ item, onSelect }: GoodsCardProps) {
+  return (
+    <div
+  className="w-[180px] h-[240px] bg-white rounded-lg p-2 shadow-md hover:shadow-lg cursor-pointer flex flex-col"
+  onClick={() => onSelect?.(item.id)}
+>
+  <div className="relative w-full h-[180px] rounded overflow-hidden">
+    <Image
+      src={item.imageUrl}
+      alt={item.name}
+      fill
+      className="object-cover"
+    />
+  </div>
+  <div className="text-center text-sm mt-2 p-1 font-semibold text-purple-700">{item.name}</div>
+</div>
+
+  );
+}

--- a/apps/oh-sang-hyeop/src/components/goods/goodsList.tsx
+++ b/apps/oh-sang-hyeop/src/components/goods/goodsList.tsx
@@ -1,0 +1,17 @@
+import GoodsCard from "./goodsCard";
+import { GoodsItem } from "@/types/goods";
+
+interface GoodsListProps {
+  goods: GoodsItem[];
+  onSelect?: (id: string) => void;
+}
+
+export default function GoodsList({ goods, onSelect }: GoodsListProps) {
+  return (
+    <div className="grid grid-cols-2 grid-rows-2 gap-2 p-2 h-full place-items-center">
+      {goods.map((item) => (
+        <GoodsCard key={item.id} item={item} onSelect={onSelect} />
+      ))}
+    </div>
+  );
+}

--- a/apps/oh-sang-hyeop/src/components/sidebar/sidebar.tsx
+++ b/apps/oh-sang-hyeop/src/components/sidebar/sidebar.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const tabs = [
+  { label: "콘서트", path: "/ticket" },
+  { label: "앨범", path: "/album" },
+  { label: "굿즈", path: "/goods" },
+];
+
+export default function Sidebar() {
+  const pathname = usePathname();
+
+  return (
+    <aside className="w-52 h-screen p-4 flex flex-col gap-4 bg-white border-r shadow">
+      {tabs.map((tab) => (
+        <Link
+          key={tab.path}
+          href={tab.path}
+          className={`flex items-center justify-center rounded-lg border p-4 text-lg font-semibold
+            hover:bg-gray-100 transition
+            ${
+              pathname.startsWith(tab.path)
+                ? "bg-purple-500 text-white border-purple-500"
+                : "text-gray-800 border-gray-300"
+            }`}
+        >
+          {tab.label}
+        </Link>
+      ))}
+    </aside>
+  );
+}

--- a/apps/oh-sang-hyeop/src/types/goods.ts
+++ b/apps/oh-sang-hyeop/src/types/goods.ts
@@ -1,0 +1,6 @@
+// types/goods.ts
+export interface GoodsItem {
+  id: string;
+  name: string;
+  imageUrl: string;
+}


### PR DESCRIPTION
### 관련 이슈
- #21
- #22

### 구현 사항
- 굿즈 페이지 BookLayout에 GoodsList 2x2 그리드 구성
- GoodsCard 컴포넌트 카드형 디자인 적용 (배경, 그림자, 중앙 이미지)
- GoodsLis### 구현 내용
- Sidebar 컴포넌트 생성
- 콘서트 / 앨범 / 굿즈 탭 항목 추가
- hover 및 활성화 상태 (보라색 강조) 스타일 적용
- BookLayout 레이아웃과 연동 그리드 행/열, gap, 카드 크기 조정

---
![image](https://github.com/user-attachments/assets/f236d8f2-86b2-4797-98c1-0bfc21863d93)
![image](https://github.com/user-attachments/assets/d40521f4-0137-4f76-9ed2-31d3378f4c66)
![image](https://github.com/user-attachments/assets/3db61ec7-9efe-4b7b-a671-cf5ebce35523)
